### PR TITLE
infra: add CODEOWNERS for infra paths [main]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Infra team — required reviewers for infrastructure paths
+.github/ @belo-app/infra


### PR DESCRIPTION
Replaces/creates CODEOWNERS to add `@belo-app/infra` as required reviewer for infra paths.

Part of BELO-2714 GitHub permissions cleanup.

> Auto-generated by codeowners-setup.sh targeting branch `main`.

**Affected paths:**
- `.github/ @belo-app/infra`
