### PR TITLE
chore: pin GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -44,10 +44,10 @@ jobs:
           target: i686-pc-windows-msvc
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - run: rustup toolchain install stable
     - run: rustup target add ${{ matrix.target }}
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: cargo build
@@ -56,13 +56,13 @@ jobs:
       if: matrix.build == 'linux' || matrix.build == 'macos'
       run: strip target/${{ matrix.target }}/release/paperback
     - name: upload unix binaries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: contains(matrix.build, 'win') == false
       with:
         name: "paperback.${{ matrix.target }}"
         path: "target/${{ matrix.target }}/release/paperback"
     - name: upload windows binaries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: contains(matrix.build, 'win')
       with:
         name: "paperback-${{ matrix.target }}.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
     name: cargo check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: rustup toolchain install stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --workspace --all-targets
@@ -42,9 +42,9 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: rustup toolchain install stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --workspace
@@ -54,9 +54,9 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: rustup toolchain install stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: rustup component add rustfmt
@@ -66,9 +66,9 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: rustup toolchain install stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: rustup component add clippy
@@ -78,14 +78,14 @@ jobs:
     name: cargo bench
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - run: rustup toolchain install stable
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - run: cargo bench --workspace
     - name: upload benchmark results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: report
         path: target/criterion/


### PR DESCRIPTION
Pin de GitHub Actions externas a su commit SHA.

| Workflow | Action | Ref original | SHA |
|---|---|---|---|
| .github/workflows/binaries.yml | actions/checkout | v4 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| .github/workflows/binaries.yml | Swatinem/rust-cache | v2 | e18b497796c12c097a38f9edb9d0641fb99eee32 |
| .github/workflows/binaries.yml | actions/upload-artifact | v4 | ea165f8d65b6e75b540449e92b4886f43607fa02 |
| .github/workflows/binaries.yml | actions/upload-artifact | v4 | ea165f8d65b6e75b540449e92b4886f43607fa02 |
| .github/workflows/ci.yml | actions/checkout | v4 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| .github/workflows/ci.yml | Swatinem/rust-cache | v2 | e18b497796c12c097a38f9edb9d0641fb99eee32 |
| .github/workflows/ci.yml | actions/checkout | v4 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| .github/workflows/ci.yml | Swatinem/rust-cache | v2 | e18b497796c12c097a38f9edb9d0641fb99eee32 |
| .github/workflows/ci.yml | actions/checkout | v4 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| .github/workflows/ci.yml | Swatinem/rust-cache | v2 | e18b497796c12c097a38f9edb9d0641fb99eee32 |
| .github/workflows/ci.yml | actions/checkout | v4 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| .github/workflows/ci.yml | Swatinem/rust-cache | v2 | e18b497796c12c097a38f9edb9d0641fb99eee32 |
| .github/workflows/ci.yml | actions/checkout | v4 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| .github/workflows/ci.yml | Swatinem/rust-cache | v2 | e18b497796c12c097a38f9edb9d0641fb99eee32 |
| .github/workflows/ci.yml | actions/upload-artifact | v4 | ea165f8d65b6e75b540449e92b4886f43607fa02 |
